### PR TITLE
abstract module signatures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,8 @@ val settings = Seq(
   version := "0.1",
   scalaVersion := "2.12.6",
   crossScalaVersions := Seq("2.11.12", "2.12.6", "2.13.0-M4"),
-  licenses := Seq("Apache-2.0" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+  licenses := Seq("Apache-2.0" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt")),
+  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6")
 )
 
 resolvers ++= Seq(
@@ -32,8 +33,6 @@ scalacOptions ++= Seq(
 
 javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation", "-source", "1.7", "-target", "1.7")
 
-addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6")
-
 lazy val core = project
   .settings(settings)
   .settings(libraryDependencies ++= Seq(
@@ -43,6 +42,6 @@ lazy val core = project
     C.scalazZioInteropCats,
     T.specs2
   ) ++ C.circe_all ++ C.cats_all ++ C.http4s_all)
-                                    
+
 lazy val root = project.in(file("."))
   .aggregate(core)

--- a/core/src/main/scala/com/github/zorechka/AppConfig.scala
+++ b/core/src/main/scala/com/github/zorechka/AppConfig.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.{Executors, ThreadPoolExecutor}
 import com.github.zorechka.HasAppConfig.Cfg
 import scalaz.zio.internal.NamedThreadFactory
 import scalaz.zio.internal.PlatformLive.ExecutorUtil
-import scalaz.zio.{IO, Task, ZIO}
 
 import scala.concurrent.ExecutionContext
 

--- a/core/src/main/scala/com/github/zorechka/Dep.scala
+++ b/core/src/main/scala/com/github/zorechka/Dep.scala
@@ -13,5 +13,3 @@ object Dep {
     dep => new ComparableVersion(dep.version)
   }
 }
-
-case class Dummy()

--- a/core/src/main/scala/com/github/zorechka/clients/Http4sClient.scala
+++ b/core/src/main/scala/com/github/zorechka/clients/Http4sClient.scala
@@ -1,34 +1,36 @@
 package com.github.zorechka.clients
 
-import cats.effect.Resource
 import com.github.zorechka.HasAppConfig
-import org.http4s.client.Client
-import org.http4s.{Request, Response}
 import org.http4s.client.blaze.BlazeClientBuilder
-import scalaz.zio
+import org.http4s.{Request, Response}
 import scalaz.zio.internal.PlatformLive
-import scalaz.zio.{Runtime, Task}
+import scalaz.zio.interop.catz._
+import scalaz.zio.{Runtime, Task, TaskR, ZIO}
 
 import scala.language.higherKinds
-import scalaz.zio.interop.catz._
 
-trait Http4sClient {
-  val http4sClient: Http4sClient.Service
+trait Http4sClient[-R] {
+  val http4sClient: Http4sClient.Service[R]
 }
 
 object Http4sClient {
-  trait Service {
-    def runRequest[T](req: Request[Task])(handler: Response[Task] => Task[T]): Task[T]
+  trait Service[-R] {
+    def runRequest[T](req: Request[Task])(handler: Response[Task] => Task[T]): TaskR[R, T]
   }
 
-  trait Live extends Http4sClient { this: HasAppConfig =>
-    val http4sClient: Service = new Http4sClient.Service {
-      implicit val rt: zio.Runtime[Any] = Runtime((), PlatformLive.fromExecutionContext(cfg.blockingCtx))
-      private val http4sClient: Resource[Task, Client[Task]] = BlazeClientBuilder[Task](cfg.blockingCtx).resource
+  trait Live extends Http4sClient[HasAppConfig] {
+    val http4sClient = new Http4sClient.Service[HasAppConfig] {
 
-      override def runRequest[T](req: Request[Task])(handler: Response[Task] => Task[T]): Task[T] = {
-        http4sClient.use(_.fetch(req)(handler))
+      override def runRequest[T](req: Request[Task])(handler: Response[Task] => Task[T]): TaskR[HasAppConfig, T] = {
+        ZIO.accessM {
+          cfg =>
+            val ec = cfg.cfg.blockingCtx
+            implicit val rt: Runtime[Any] = Runtime((), PlatformLive.fromExecutionContext(ec))
+
+            BlazeClientBuilder[Task](ec).resource.use(_.fetch(req)(handler))
+        }
       }
+
     }
   }
 }

--- a/core/src/main/scala/com/github/zorechka/dependency/BazelDepsCheck.scala
+++ b/core/src/main/scala/com/github/zorechka/dependency/BazelDepsCheck.scala
@@ -5,8 +5,7 @@ import java.nio.file.{Files, Path}
 import com.github.zorechka.Dep
 import com.github.zorechka.utils.RunProcess.execCmd
 
-import collection.JavaConverters._
-
+import scala.collection.JavaConverters._
 import scala.util.Try
 
 object BazelDepsCheck {

--- a/core/src/main/scala/com/github/zorechka/repos/GithubRepos.scala
+++ b/core/src/main/scala/com/github/zorechka/repos/GithubRepos.scala
@@ -4,22 +4,23 @@ import java.io.File
 import java.nio.file.Files
 
 import com.github.zorechka.HasAppConfig
-import scalaz.zio.{Task, TaskR, ZIO}
+import scalaz.zio.{TaskR, ZIO}
 
-import collection.JavaConverters._
+import scala.collection.JavaConverters._
 
 case class GitRepo(owner: String, name: String, url: String)
-trait GithubRepos {
-  val repos: GithubRepos.Service
+
+trait GithubRepos[-R] {
+  val repos: GithubRepos.Service[R]
 }
 
 object GithubRepos {
-  trait Service {
-    def reposToCheck(): TaskR[HasAppConfig, List[GitRepo]]
+  trait Service[-R] {
+    def reposToCheck(): TaskR[R, List[GitRepo]]
   }
 
-  trait Live extends GithubRepos {
-    val repos: GithubRepos.Service = new GithubRepos.Service {
+  trait Live extends GithubRepos[HasAppConfig] {
+    val repos = new GithubRepos.Service[HasAppConfig] {
       private val regex = """-\s+(.+)/(.+)""".r
 
       override def reposToCheck(): TaskR[HasAppConfig, List[GitRepo]] = for {

--- a/core/src/main/scala/com/github/zorechka/utils/Resources.scala
+++ b/core/src/main/scala/com/github/zorechka/utils/Resources.scala
@@ -3,7 +3,7 @@ package com.github.zorechka.utils
 import java.io.File
 import java.nio.file.Files
 
-import collection.JavaConverters._
+import scala.collection.JavaConverters._
 
 object Resources {
   def readAllLines(filename: String): List[String] = {

--- a/core/src/main/scala/com/github/zorechka/utils/RunProcess.scala
+++ b/core/src/main/scala/com/github/zorechka/utils/RunProcess.scala
@@ -1,6 +1,5 @@
 package com.github.zorechka.utils
 
-import java.io.IOException
 import java.nio.file.Path
 
 import scala.collection.mutable.ListBuffer

--- a/core/src/test/scala/com/github/zorechka/clients/MavenCentralClientTest.scala
+++ b/core/src/test/scala/com/github/zorechka/clients/MavenCentralClientTest.scala
@@ -2,8 +2,8 @@ package com.github.zorechka.clients
 
 import com.github.zorechka.{Dep, HasAppConfig}
 import org.specs2.mutable.Specification
-import scalaz.zio.{DefaultRuntime, Runtime}
 import scalaz.zio.internal.PlatformLive
+import scalaz.zio.{DefaultRuntime, Runtime}
 
 class MavenCentralClientTest extends Specification with DefaultRuntime {
   "MavenCentralClient" should {
@@ -11,7 +11,7 @@ class MavenCentralClientTest extends Specification with DefaultRuntime {
       val rt = Runtime(new HasAppConfig.Live with Http4sClient.Live, PlatformLive.Default)
 
       val searchDep = Dep("org.scalacheck", "scalacheck_2.12", "1.10.0")
-      val mavenCentral = new MavenCentralClient.Live {}
+      val mavenCentral = new MavenCentralClient.Live[HasAppConfig.Live with Http4sClient.Live] {}
       val call = mavenCentral.client.allVersions(searchDep)
 
       val result = rt.unsafeRunSync(call)


### PR DESCRIPTION
Some interfaces unnecessarily leak their implementation details, e.g. in:
```scala
trait MavenCentralClient {
  val client: MavenCentralClient.Service
}

object MavenCentralClient {
  trait Service {
    def allVersions(dep: Dep): ZIO[Http4sClient, Throwable, List[Dep]]
  }
}
```

The `Http4sClient` dependency is hardcoded – an implementation detail is exposed in interface, this also prevents creating an instance with no- or other environment dependencies instead of `Http4sClient`

This PR moves all environment dependencies into a parameter instead, preserving abstraction:

```scala
trait MavenCentralClient[-R] {
  val client: MavenCentralClient.Service[R]
}

object MavenCentralClient {
  trait Service[-R] {
    def allVersions(dep: Dep): ZIO[R, Throwable, List[Dep]]
  }
}
```